### PR TITLE
Implement support for curl multi-handles.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,6 @@ name = "curl-inject-opt-preload"
 version = "0.2.0"
 dependencies = [
  "curl-inject-opt-shared 0.2.0",
- "curl-sys 0.4.30+curl-7.69.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright 2018-2019 Maarten de Vries <maarten@de-vri.es>
+Copyright 2018-2020 Maarten de Vries <maarten@de-vri.es>
+Copyright 2020 Fizyr B.V.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ The subcommand will be run with `/path/to/libcurl-inject-opt-preload.so` added t
 and a list of options to set in the `CURL_INJECT_OPT` environment variable.
 The command-line tool takes care of these steps automatically.
 
-The preloaded library will intercept calls to `curl_easy_perform()`.
+The preloaded library will intercept calls to `curl_easy_perform()` and `curl_multi_add_handle()`.
 Whenever a call is intercepted, the options listed in `CURL_INJECT_OPT` are set on the relevant CURL handle
-before the original `curl_easy_perform()` is called.
+before the original function is called.
 
 This can be used to take advantage of certain CURL features even if the program being run doesn't expose them.
 Currently, supported options include timeout options, TLS client certificate settings, proxy settings, and `CURLOPT_VERBOSE`.
@@ -72,7 +72,7 @@ Although not recommended, it is possible to make `curl-inject-opt` work even wit
 
 To make `curl-inject-opt` work with secure execution mode, the entry added to `LD_PRELOAD` must consist only of the library name `libcurl-inject-opt.so` with no path information.
 The library must be found by the dynamic linker in the default search path and the library must have the `setuid` permission bit set.
-This can party be achieved by configuring the project with `./configure PREFIX=/usr RELY_ON_SEARCH=1`.
+This can partly be achieved by configuring the project with `./configure PREFIX=/usr RELY_ON_SEARCH=1`.
 See `./configure --help` for more information.
 
 It is up to the packager or installer to set the `setuid` bit of the installed library, if desired.

--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name    = "curl-inject-opt"
 version = "0.2.0"
-authors = ["Maarten de Vries <maarten@de-vri.es>"]
+authors = [
+	"Maarten de Vries <maarten@de-vri.es>",
+	"Fizyr B.V.",
+]
 edition = "2018"
 license = "BSD-2-Clause"
 

--- a/application/src/bin/curl-inject-opt.rs
+++ b/application/src/bin/curl-inject-opt.rs
@@ -27,6 +27,10 @@ use std::path::PathBuf;
 use yansi::Paint;
 
 fn main() {
+	if !curl_inject_opt::should_color(2) {
+		Paint::disable();
+	}
+
 	let args       = curl_inject_opt::build_cli().get_matches();
 	let print_env  = args.is_present("print-env");
 	let debug      = args.is_present("debug");

--- a/application/src/bin/curl-inject-opt.rs
+++ b/application/src/bin/curl-inject-opt.rs
@@ -24,6 +24,7 @@
 use curl_inject_opt_shared::{config, serialize_options};
 use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
+use yansi::Paint;
 
 fn main() {
 	let args       = curl_inject_opt::build_cli().get_matches();
@@ -40,7 +41,7 @@ fn main() {
 	let set_options = match curl_inject_opt::extract_curl_options(&args) {
 		Ok(x)  => x,
 		Err(e) => {
-			eprintln!("{}", e);
+			eprintln!("{} {}", Paint::red("Error:").bold(), e);
 			std::process::exit(1);
 		}
 	};
@@ -69,7 +70,7 @@ fn main() {
 		let new_preload = match std::env::join_paths(std::iter::once(preload_lib.clone()).chain(std::env::split_paths(&old_preload))) {
 			Ok(x) => x,
 			Err(_) => {
-				println!("preload library path contains separator: {}", preload_lib.display());
+				eprintln!("{}: preload library path contains separator: {}", Paint::red("Error:").bold(), preload_lib.display());
 				std::process::exit(1);
 			}
 		};
@@ -89,6 +90,6 @@ fn main() {
 	child.env("CURL_INJECT_OPT", std::ffi::OsStr::from_bytes(&serialized_options));
 
 	let error = child.exec();
-	eprintln!("Failed to execute command: {}", error);
-	std::process::exit(-1);
+	eprintln!("{} failed to execute command: {}", Paint::red("Error:").bold(), error);
+	std::process::exit(2);
 }

--- a/application/src/bin/install.rs
+++ b/application/src/bin/install.rs
@@ -157,6 +157,10 @@ fn install() -> Result<(), String> {
 }
 
 fn main() {
+	if !curl_inject_opt::should_color(2) {
+		Paint::disable();
+	}
+
 	if let Err(error) = install() {
 		eprintln!("{} {}",
 			Paint::red("Error:").bold(),

--- a/application/src/lib.rs
+++ b/application/src/lib.rs
@@ -81,3 +81,13 @@ pub fn extract_curl_options(matches: &clap::ArgMatches) -> Result<Vec<SetOption>
 	// Parse the options.
 	options.into_iter().map(|((option, value), _)| SetOption::parse_value(*option, value.as_bytes())).collect()
 }
+
+pub fn should_color(fd: i32) -> bool {
+	if std::env::var_os("CLI_COLOR").map(|x| x == "0") == Some(true) {
+		false
+	} else if std::env::var_os("CLI_COLOR_FORCE").map(|x| x != "0") == Some(true) {
+		true
+	} else {
+		unsafe { libc::isatty(fd) != 0 }
+	}
+}

--- a/preload/Cargo.toml
+++ b/preload/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name    = "curl-inject-opt-preload"
 version = "0.2.0"
-authors = ["Maarten de Vries <maarten@de-vri.es>"]
+authors = [
+	"Maarten de Vries <maarten@de-vri.es>",
+	"Fizyr B.V.",
+]
 edition = "2018"
 license = "BSD-2-Clause"
 

--- a/preload/Cargo.toml
+++ b/preload/Cargo.toml
@@ -10,5 +10,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 curl-inject-opt-shared = { path = "../shared" }
-libc      = "0.2.48"
-curl-sys  = "0.4.16"
+libc = "0.2.48"

--- a/preload/src/lib.rs
+++ b/preload/src/lib.rs
@@ -24,7 +24,20 @@
 use std::ffi::CStr;
 use std::os::unix::ffi::OsStrExt;
 
-use curl_inject_opt_shared::{CURL, CURLcode, CurlEasySetOpt, CurlEasyPerform, SetOption, parse_options};
+use curl_inject_opt_shared::SetOption;
+use curl_inject_opt_shared::Value;
+use curl_inject_opt_shared::parse_options;
+use curl_inject_opt_shared::reexports::curl_sys;
+
+use curl_sys::CURL;
+use curl_sys::CURLM;
+use curl_sys::CURLMcode;
+use curl_sys::CURLcode;
+use curl_sys::CURLoption;
+
+type CurlEasySetOpt  = extern "C" fn(handle: *mut CURL, option: CURLoption, ...) -> CURLcode;
+type CurlEasyPerform = extern "C" fn(handle: *mut CURL) -> CURLcode;
+type CurlMultiAddHandle = extern "C" fn(multi_handle: *mut CURLM, handle: *mut CURL) -> CURLMcode;
 
 macro_rules! load_next_fn {
 	( $name:ident : $type:ty ) => {{
@@ -51,10 +64,20 @@ macro_rules! load_next_fn {
 }
 
 struct CurlInjectOpt {
-	curl_easy_perform : CurlEasyPerform,
-	curl_easy_setopt  : CurlEasySetOpt,
-	options           : Vec<SetOption>,
-	debug             : bool,
+	/// The original curl_easy_perform function.
+	curl_easy_perform: CurlEasyPerform,
+
+	/// The original curl_east_setopt function.
+	curl_easy_setopt: CurlEasySetOpt,
+
+	/// The original curl_multi_add_handle function.
+	curl_multi_add_handle: CurlMultiAddHandle,
+
+	/// The options to set on all handles.
+	options: Vec<SetOption>,
+
+	/// If true, run in debug mode, printing what we're doing.
+	debug: bool,
 }
 
 fn env_bool(name: &str) -> bool {
@@ -67,12 +90,13 @@ fn env_bool(name: &str) -> bool {
 
 impl CurlInjectOpt {
 	fn init() -> Result<Self, String> {
-		let curl_easy_perform = load_next_fn!(curl_easy_perform : CurlEasyPerform);
-		let curl_easy_setopt  = load_next_fn!(curl_easy_setopt  : CurlEasySetOpt);
-		let debug             = env_bool("CURL_INJECT_OPT_DEBUG");
-		let no_inherit        = std::env::var_os("CURL_INJECT_OPT_NO_INHERIT");
-		let options           = std::env::var_os("CURL_INJECT_OPT");
-		let options           = options.map(|x| parse_options(x.as_bytes()).expect("failed to parse CURL_INJECT_OPT")).unwrap_or_default();
+		let curl_easy_perform     = load_next_fn!(curl_easy_perform     : CurlEasyPerform);
+		let curl_easy_setopt      = load_next_fn!(curl_easy_setopt      : CurlEasySetOpt);
+		let curl_multi_add_handle = load_next_fn!(curl_multi_add_handle : CurlMultiAddHandle);
+		let debug                 = env_bool("CURL_INJECT_OPT_DEBUG");
+		let no_inherit            = std::env::var_os("CURL_INJECT_OPT_NO_INHERIT");
+		let options               = std::env::var_os("CURL_INJECT_OPT");
+		let options               = options.map(|x| parse_options(x.as_bytes()).expect("failed to parse CURL_INJECT_OPT")).unwrap_or_default();
 
 		if let Some(path) = no_inherit {
 			if let Some(preload) = std::env::var_os("LD_PRELOAD") {
@@ -88,11 +112,15 @@ impl CurlInjectOpt {
 			if let Some(err) = curl_easy_setopt.as_ref().err() {
 				eprintln!("curl-inject-opt: {}", err);
 			}
+			if let Some(err) = curl_multi_add_handle.as_ref().err() {
+				eprintln!("curl-inject-opt: {}", err);
+			}
 		}
 
 		let result = Self {
 			curl_easy_perform: curl_easy_perform?,
-			curl_easy_setopt:  curl_easy_setopt?,
+			curl_easy_setopt: curl_easy_setopt?,
+			curl_multi_add_handle: curl_multi_add_handle?,
 			options,
 			debug,
 		};
@@ -104,7 +132,10 @@ impl CurlInjectOpt {
 		if self.debug {
 			eprintln!("curl-inject-opt: setting option {}: {}", option.name, option.value);
 		}
-		let code = option.set(self.curl_easy_setopt, handle);
+		let code = match &option.value {
+			Value::CString(x) => (self.curl_easy_setopt)(handle, option.option, x.as_ref() as *const CStr),
+			Value::CLong(x)   => (self.curl_easy_setopt)(handle, option.option, *x),
+		};
 		if code != curl_sys::CURLE_OK {
 			eprintln!("curl-inject-opt: failed to set option {}: error {}", option.name, code);
 		}
@@ -149,4 +180,20 @@ pub extern "C" fn curl_easy_perform(handle: *mut CURL) -> CURLcode {
 	// Set options, then delegate to the real handler.
 	init.set_options(handle);
 	(init.curl_easy_perform)(handle)
+}
+
+#[no_mangle]
+pub extern "C" fn curl_multi_add_handle(multi_handle: *mut CURLM, handle: *mut CURL) -> CURLMcode {
+	let init = match unsafe { _INIT.as_ref().unwrap() } {
+		Err(string) => panic!("{}", string),
+		Ok(init)    => init,
+	};
+
+	if init.debug {
+		eprintln!("curl-inject-opt: curl_multi_add_handle() called");
+	}
+
+	// Set options, then delegate to the real handler.
+	init.set_options(handle);
+	(init.curl_multi_add_handle)(multi_handle, handle)
 }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -7,4 +7,4 @@ license = "BSD-2-Clause"
 build   = "build.rs"
 
 [dependencies]
-curl-sys     = "0.4.16"
+curl-sys = "0.4.16"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name    = "curl-inject-opt-shared"
 version = "0.2.0"
-authors = ["Maarten de Vries <maarten@de-vri.es>"]
+authors = [
+	"Maarten de Vries <maarten@de-vri.es>",
+	"Fizyr B.V.",
+]
 edition = "2018"
 license = "BSD-2-Clause"
 build   = "build.rs"

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -27,12 +27,9 @@ mod options;
 
 pub use self::options::{Kind, Value, Meta, SetOption, OPTIONS};
 
-pub use curl_sys::CURL;
-pub use curl_sys::CURLoption;
-pub use curl_sys::CURLcode;
-
-pub type CurlEasySetOpt  = extern "C" fn(handle: *mut CURL, option: CURLoption, ...) -> CURLcode;
-pub type CurlEasyPerform = extern "C" fn(handle: *mut CURL) -> CURLcode;
+pub mod reexports {
+	pub use curl_sys;
+}
 
 fn encode_option_append(buffer: &mut Vec<u8>, option: &SetOption) {
 	buffer.extend(option.name.as_bytes());

--- a/shared/src/options.rs
+++ b/shared/src/options.rs
@@ -21,10 +21,10 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use super::{CURL, CURLcode, CURLoption, CurlEasySetOpt};
-
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 use std::os::raw::c_long;
+
+use curl_sys::CURLoption;
 
 macro_rules! curl_option {
 	( $name:literal, $curl_name:ident, $type:expr, $help:literal ) => {
@@ -183,13 +183,5 @@ impl SetOption {
 		}
 
 		Err(format!("unknown option: {}", name))
-	}
-
-	/// Set the value of this CURL option for a CURL easy handle.
-	pub fn set(&self, curl_easy_setopt: CurlEasySetOpt, handle: *mut CURL) -> CURLcode {
-		match &self.value {
-			Value::CString(x) => curl_easy_setopt(handle, self.option, x.as_ref() as *const CStr),
-			Value::CLong(x)   => curl_easy_setopt(handle, self.option, *x),
-		}
 	}
 }


### PR DESCRIPTION
This PR does a small refactor and it adds support for CURL multi-handles.

It intercepts `curl_multi_add_handle` to apply the wanted options to the CURL easy-handle, before passing it to the original `curl_multi_add_handle`. 